### PR TITLE
Bug/fails to accept new bounding props

### DIFF
--- a/src/in-view.js
+++ b/src/in-view.js
@@ -13,7 +13,6 @@ export default class InView extends React.Component {
     boundingRight: number,
     children: func.isRequired,
     debounce: number,
-    horizontally: bool,
     once: bool,
     threshold: number,
   }

--- a/src/in-view.js
+++ b/src/in-view.js
@@ -49,11 +49,11 @@ export default class InView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { threshold, debounce } = nextProps
+    const { threshold, debounce, boundingLeft, boundingRight } = nextProps
     this.isInViewport = inViewport({
       threshold,
-      boundingLeft: this.props.boundingLeft,
-      boundingRight: this.props.boundingRight,
+      boundingLeft,
+      boundingRight,
       requireEntireElementInViewport: true,
     })
     this.checkIsInViewDebounced = debounceFn(this.checkIsInView, debounce)

--- a/src/in-view.js
+++ b/src/in-view.js
@@ -48,15 +48,23 @@ export default class InView extends React.Component {
     this.scrollUnsubscribe()
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { threshold, debounce, boundingLeft, boundingRight } = nextProps
-    this.isInViewport = inViewport({
-      threshold,
-      boundingLeft,
-      boundingRight,
-      requireEntireElementInViewport: true,
-    })
-    this.checkIsInViewDebounced = debounceFn(this.checkIsInView, debounce)
+  componentDidUpdate(prevProps) {
+    const { threshold, debounce, boundingLeft, boundingRight } = this.props
+    if (
+      prevProps.threshold !== threshold ||
+      prevProps.boundingLeft !== boundingLeft ||
+      prevProps.boundingRight !== boundingRight
+    ) {
+      this.isInViewport = inViewport({
+        threshold,
+        boundingLeft,
+        boundingRight,
+        requireEntireElementInViewport: true,
+      })
+    }
+    if (prevProps.debounce !== debounce) {
+      this.checkIsInViewDebounced = debounceFn(this.checkIsInView, debounce)
+    }
   }
 
   checkIsInView = () => {

--- a/src/in-view.test.js
+++ b/src/in-view.test.js
@@ -156,3 +156,26 @@ test('boundingRight continues to work even after prop change', async () => {
   scroll()
   await wait(() => expect(getBox()).toHaveTextContent('false'))
 })
+
+test('inViewport accepts changed bounding props', async () => {
+  const { getBox, setBoundingRect, rerender, scroll } = renderInView({
+    debounce: 1,
+    boundingLeft: 100,
+    boundingRight: 300,
+  })
+  setBoundingRect({
+    top: 0,
+    bottom: 100,
+    left: 50,
+    right: 350,
+  })
+  await wait(() => expect(getBox()).toHaveTextContent('false'))
+  // Now should be in-bounds.
+  rerender({
+    debounce: 1,
+    boundingLeft: 50,
+    boundingRight: 350,
+  })
+  scroll()
+  await wait(() => expect(getBox()).toHaveTextContent('true'))
+})


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, etc)

* Fix: although isInViewport was getting the `boundingLeft` and `boundingRight`, it was retaining the original value.
* Feat: only re-initialize debounced function and isInViewport when the related props change.

#### Relevant Links (bug reports, etc)

## Checklist

* [x] Added tests / did not decrease code coverage
* [ ] Tested across browsers
