### PR TITLE
Feat/partial visibility

### DIFF
--- a/src/in-view.js
+++ b/src/in-view.js
@@ -15,7 +15,7 @@ export default class InView extends React.Component {
     children: func.isRequired,
     debounce: number,
     once: bool,
-    requireEntireElementInViewport: bool,
+    isFullyContained: bool,
     threshold: number,
   }
 
@@ -23,7 +23,7 @@ export default class InView extends React.Component {
     debounce: 250,
     threshold: 0,
     once: false,
-    requireEntireElementInViewport: true,
+    isFullyContained: true,
   }
 
   mounted = false
@@ -39,13 +39,13 @@ export default class InView extends React.Component {
       threshold,
       boundingLeft,
       boundingRight,
-      requireEntireElementInViewport,
+      isFullyContained,
     } = this.props
     this.isInViewport = inViewport({
       threshold,
       boundingLeft,
       boundingRight,
-      requireEntireElementInViewport,
+      isFullyContained,
     })
     this.checkIsInView()
     this.scrollUnsubscribe = onWindowScroll(this.checkIsInViewDebounced)
@@ -62,20 +62,19 @@ export default class InView extends React.Component {
       debounce,
       boundingLeft,
       boundingRight,
-      requireEntireElementInViewport,
+      isFullyContained,
     } = this.props
     if (
       prevProps.threshold !== threshold ||
       prevProps.boundingLeft !== boundingLeft ||
       prevProps.boundingRight !== boundingRight ||
-      prevProps.requireEntireElementInViewport !==
-        requireEntireElementInViewport
+      prevProps.isFullyContained !== isFullyContained
     ) {
       this.isInViewport = inViewport({
         threshold,
         boundingLeft,
         boundingRight,
-        requireEntireElementInViewport,
+        isFullyContained,
       })
     }
     if (prevProps.debounce !== debounce) {

--- a/src/in-view.js
+++ b/src/in-view.js
@@ -15,6 +15,7 @@ export default class InView extends React.Component {
     children: func.isRequired,
     debounce: number,
     once: bool,
+    requireEntireElementInViewport: bool,
     threshold: number,
   }
 
@@ -22,6 +23,7 @@ export default class InView extends React.Component {
     debounce: 250,
     threshold: 0,
     once: false,
+    requireEntireElementInViewport: true,
   }
 
   mounted = false
@@ -33,11 +35,17 @@ export default class InView extends React.Component {
 
   componentDidMount() {
     this.mounted = true
+    const {
+      threshold,
+      boundingLeft,
+      boundingRight,
+      requireEntireElementInViewport,
+    } = this.props
     this.isInViewport = inViewport({
-      threshold: this.props.threshold,
-      boundingLeft: this.props.boundingLeft,
-      boundingRight: this.props.boundingRight,
-      requireEntireElementInViewport: true,
+      threshold,
+      boundingLeft,
+      boundingRight,
+      requireEntireElementInViewport,
     })
     this.checkIsInView()
     this.scrollUnsubscribe = onWindowScroll(this.checkIsInViewDebounced)
@@ -49,17 +57,25 @@ export default class InView extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { threshold, debounce, boundingLeft, boundingRight } = this.props
+    const {
+      threshold,
+      debounce,
+      boundingLeft,
+      boundingRight,
+      requireEntireElementInViewport,
+    } = this.props
     if (
       prevProps.threshold !== threshold ||
       prevProps.boundingLeft !== boundingLeft ||
-      prevProps.boundingRight !== boundingRight
+      prevProps.boundingRight !== boundingRight ||
+      prevProps.requireEntireElementInViewport !==
+        requireEntireElementInViewport
     ) {
       this.isInViewport = inViewport({
         threshold,
         boundingLeft,
         boundingRight,
-        requireEntireElementInViewport: true,
+        requireEntireElementInViewport,
       })
     }
     if (prevProps.debounce !== debounce) {

--- a/src/in-view.test.js
+++ b/src/in-view.test.js
@@ -182,12 +182,12 @@ test('inViewport accepts changed bounding props', async () => {
   await wait(() => expect(getBox()).toHaveTextContent('true'))
 })
 
-test('inViewport returns true for requireEntireElementInViewport=false', async () => {
+test('inViewport returns true for isFullyContained=false', async () => {
   const { getBox, setBoundingRect } = renderInView({
     debounce: 1,
     boundingLeft: 100,
     boundingRight: 300,
-    requireEntireElementInViewport: false,
+    isFullyContained: false,
   })
   setBoundingRect({
     top: -100,
@@ -198,12 +198,12 @@ test('inViewport returns true for requireEntireElementInViewport=false', async (
   await wait(() => expect(getBox()).toHaveTextContent('true'))
 })
 
-test('inViewport accepts changed requireEntireElementInViewport prop', async () => {
+test('inViewport accepts changed isFullyContained prop', async () => {
   const { getBox, setBoundingRect, rerender, scroll } = renderInView({
     debounce: 1,
     boundingLeft: 100,
     boundingRight: 300,
-    requireEntireElementInViewport: true,
+    isFullyContained: true,
   })
   setBoundingRect({
     top: -100,
@@ -214,7 +214,7 @@ test('inViewport accepts changed requireEntireElementInViewport prop', async () 
   await wait(() => expect(getBox()).toHaveTextContent('false'))
   // Now should be in-bounds.
   rerender({
-    requireEntireElementInViewport: false,
+    isFullyContained: false,
   })
   scroll()
   await wait(() => expect(getBox()).toHaveTextContent('true'))

--- a/src/in-view.test.js
+++ b/src/in-view.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, wait } from 'react-testing-library'
+import { fireEvent, render, wait, cleanup } from 'react-testing-library'
 import InView from './in-view'
 import 'dom-testing-library/extend-expect'
 
@@ -48,6 +48,8 @@ const renderInView = (props) => {
     },
   }
 }
+
+afterEach(cleanup)
 
 test('renders as true when visible', async () => {
   const { getBox, setBoundingRect } = renderInView()
@@ -175,6 +177,44 @@ test('inViewport accepts changed bounding props', async () => {
     debounce: 1,
     boundingLeft: 50,
     boundingRight: 350,
+  })
+  scroll()
+  await wait(() => expect(getBox()).toHaveTextContent('true'))
+})
+
+test('inViewport returns true for requireEntireElementInViewport=false', async () => {
+  const { getBox, setBoundingRect } = renderInView({
+    debounce: 1,
+    boundingLeft: 100,
+    boundingRight: 300,
+    requireEntireElementInViewport: false,
+  })
+  setBoundingRect({
+    top: -100,
+    bottom: 100,
+    left: 50,
+    right: 200,
+  })
+  await wait(() => expect(getBox()).toHaveTextContent('true'))
+})
+
+test('inViewport accepts changed requireEntireElementInViewport prop', async () => {
+  const { getBox, setBoundingRect, rerender, scroll } = renderInView({
+    debounce: 1,
+    boundingLeft: 100,
+    boundingRight: 300,
+    requireEntireElementInViewport: true,
+  })
+  setBoundingRect({
+    top: -100,
+    bottom: 100,
+    left: 50,
+    right: 200,
+  })
+  await wait(() => expect(getBox()).toHaveTextContent('false'))
+  // Now should be in-bounds.
+  rerender({
+    requireEntireElementInViewport: false,
   })
   scroll()
   await wait(() => expect(getBox()).toHaveTextContent('true'))

--- a/src/util.js
+++ b/src/util.js
@@ -39,7 +39,7 @@ export const inViewport = ({
   offsetHoriz = window.innerWidth * threshold,
   boundingLeft,
   boundingRight,
-  requireEntireElementInViewport = false,
+  isFullyContained = false,
 } = {}) => (element) => {
   if (!element) return false
   if (!element.offsetParent) return true
@@ -55,6 +55,6 @@ export const inViewport = ({
       left: isNaN(boundingLeft) ? horizMin : boundingLeft,
       right: isNaN(boundingRight) ? horizMax : boundingRight,
     },
-    fullyContained: requireEntireElementInViewport,
+    fullyContained: isFullyContained,
   })
 }

--- a/src/util.js
+++ b/src/util.js
@@ -11,7 +11,7 @@ export const on = (evtName, opts) => (el) => (fn) => {
 const isBetween = (minInclusive, max) => (target) =>
   Math.max(Math.min(max, target), minInclusive) === target
 
-const isBoundingClientRectInRange = ({
+export const isBoundingClientRectInRange = ({
   targetRect,
   boundingRect,
   fullyContained,
@@ -23,10 +23,14 @@ const isBoundingClientRectInRange = ({
         horizBounds(targetRect.right) &&
         vertBounds(targetRect.top) &&
         vertBounds(targetRect.bottom)
-    : horizBounds(targetRect.left) ||
-        horizBounds(targetRect.right) ||
-        vertBounds(targetRect.top) ||
-        vertBounds(targetRect.bottom)
+    : (horizBounds(targetRect.left) &&
+        (vertBounds(targetRect.top) || vertBounds(targetRect.bottom))) ||
+        (horizBounds(targetRect.right) &&
+          (vertBounds(targetRect.top) || vertBounds(targetRect.bottom))) ||
+        (vertBounds(targetRect.top) &&
+          (horizBounds(targetRect.left) || horizBounds(targetRect.right))) ||
+        (vertBounds(targetRect.bottom) &&
+          (horizBounds(targetRect.left) || horizBounds(targetRect.right)))
 }
 
 export const inViewport = ({

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,4 +1,31 @@
-import { inViewport, on } from './util'
+import { inViewport, isBoundingClientRectInRange, on } from './util'
+
+const toRect = (value) => {
+  const [top, right, bottom, left] = value.split(',').map(Number)
+  return { top, right, bottom, left }
+}
+const FULL_SCREEN = '0,1000,1000,0'
+test.each`
+  target                 | bounding             | fullyContained | expected
+  ${'100,200,200,100'}   | ${FULL_SCREEN}       | ${true}        | ${true}
+  ${'500,500,600,400'}   | ${FULL_SCREEN}       | ${true}        | ${true}
+  ${'-300,600,100,500'}  | ${FULL_SCREEN}       | ${true}        | ${false}
+  ${'100,200,200,100'}   | ${'100,400,200,300'} | ${false}       | ${false}
+  ${'-300,600,100,500'}  | ${FULL_SCREEN}       | ${false}       | ${true}
+  ${'900,100,1100,-100'} | ${FULL_SCREEN}       | ${false}       | ${true}
+  ${'900,1100,1100,900'} | ${FULL_SCREEN}       | ${false}       | ${true}
+  ${'-100,100,100,-100'} | ${FULL_SCREEN}       | ${false}       | ${true}
+  ${'-100,1100,100,900'} | ${FULL_SCREEN}       | ${false}       | ${true}
+`(
+  'returns $expected when target=$target, bounding=$bounding, fullyContained=$fullyContained',
+  ({ target, bounding, fullyContained, expected }) => {
+    const targetRect = toRect(target)
+    const boundingRect = toRect(bounding)
+    expect(
+      isBoundingClientRectInRange({ targetRect, boundingRect, fullyContained })
+    ).toEqual(expected)
+  }
+)
 
 describe('inViewport', () => {
   // jsdom window dimentions:


### PR DESCRIPTION
## Change Type

* [x] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [x] minor
* [ ] patch

## Further Information (screenshots, etc)

- Partial containment calculation was broken.
- Converted `requireEntireElementInViewport` to `isFullyContained`
- Exposed `isFullyContained` as a prop on the `InView` component.

#### Relevant Links (bug reports, etc)

## Checklist

* [x] Added tests / did not decrease code coverage
* [ ] Tested across browsers
